### PR TITLE
Gnosis Chain Support

### DIFF
--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -317,7 +317,8 @@ mod tests {
                                 "chainId": "0x1",
                                 "v": "0x0",
                                 "r": "0x269746c7467dcb8d6535ff2ec3cc2257872bd9f55564b1b364e750263f831902",
-                                "s": "0x2c391ac90acdd9cf0f4e28f3647a9be74b05a7b261a83c0ae8199c733012a415"
+                                "s": "0x2c391ac90acdd9cf0f4e28f3647a9be74b05a7b261a83c0ae8199c733012a415",
+                                "yParity": "0x1"
                               }
                         ],
                         "transactionsRoot": "0xfe498a1338059330121151a24a01070321a63bbd2c82607ae747a26cd493e141",

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -263,11 +263,7 @@ mod tests {
 
     #[test]
     fn batch_request() {
-        let (
-            latest, 
-            safe,
-            receipts
-        ) = call(
+        let (latest, safe, receipts) = call(
             (
                 (eth::BlockNumber, Empty),
                 (eth::GetBlockByNumber, (BlockTag::Safe.into(), Hydrated::Yes)),

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -263,7 +263,11 @@ mod tests {
 
     #[test]
     fn batch_request() {
-        let (latest, safe, receipts) = call(
+        let (
+            latest, 
+            safe,
+            receipts
+        ) = call(
             (
                 (eth::BlockNumber, Empty),
                 (eth::GetBlockByNumber, (BlockTag::Safe.into(), Hydrated::Yes)),
@@ -298,28 +302,27 @@ mod tests {
                         "timestamp": "0x62b147f5",
                         "totalDifficulty": "0xb0e7fa732d136d6e1f4",
                         "transactions": [
-                          {
-                            "accessList": [],
-                            "blockHash": "0x0950f85eb900296a98747b00ff2acfdeb1e5dba5060ee3fd25b83aaec6b24215",
-                            "blockNumber": "0xe4e364",
-                            "chainId": "0x1",
-                            "from": "0xbcbd4885ee8b2b74249c5ad9b8b668fb256a51b1",
-                            "gas": "0xb57a",
-                            "gasPrice": "0xbcba73007",
-                            "hash": "0x9893b05d6c714967f301b929d3b133c84607eb142aeaa8f6efe791c071906458",
-                            "input": "0x095ea7b3000000000000000000000000881d40237659c251811cec9c364ef91dc08d300cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                            "maxFeePerGas": "0x10882e96a0",
-                            "maxPriorityFeePerGas": "0x4fd24321",
-                            "nonce": "0xb20",
-                            "r": "0x576baaa1748639f39fdb655b6dfd3e9318b412942d1ab468a2254ac08a094f9f",
-                            "s": "0x2e8d5cb746b8ec3902444858ac11fc7e6acb7d993cdbc6945e59fc804a76dc2b",
-                            "to": "0x6b175474e89094c44da98b954eedeac495271d0f",
-                            "transactionIndex": "0x0",
-                            "type": "0x2",
-                            "v": "0x0",
-                            "value": "0x0",
-                            "yParity": "0x0"
-                          }
+                            {
+                                "blockHash": "0x0950f85eb900296a98747b00ff2acfdeb1e5dba5060ee3fd25b83aaec6b24215",
+                                "blockNumber": "0xe4e364",
+                                "from": "0x475ef7c1493bb29642529c30ad9bd4d1f27aed98",
+                                "gas": "0xc05a",
+                                "gasPrice": "0xba43b7400",
+                                "maxPriorityFeePerGas": "0x9502f900",
+                                "maxFeePerGas": "0xba43b7400",
+                                "hash": "0x20ea0eb2a3a3928ccfa86246fdf5f1f4ddd8c98a04f67ace5e149e22ecfe6b3a",
+                                "input": "0xa22cb4650000000000000000000000001e0049783f008a0085193e00003d00cd54003c710000000000000000000000000000000000000000000000000000000000000001",
+                                "nonce": "0x26a",
+                                "to": "0x2ee6af0dff3a1ce3f7e3414c52c48fd50d73691e",
+                                "transactionIndex": "0x87",
+                                "value": "0x0",
+                                "type": "0x2",
+                                "accessList": [],
+                                "chainId": "0x1",
+                                "v": "0x0",
+                                "r": "0x269746c7467dcb8d6535ff2ec3cc2257872bd9f55564b1b364e750263f831902",
+                                "s": "0x2c391ac90acdd9cf0f4e28f3647a9be74b05a7b261a83c0ae8199c733012a415"
+                              }
                         ],
                         "transactionsRoot": "0xfe498a1338059330121151a24a01070321a63bbd2c82607ae747a26cd493e141",
                         "uncles": []
@@ -358,6 +361,6 @@ mod tests {
             }
         );
         assert_eq!(latest, 0x1163fd1);
-        assert_eq!(safe.unwrap().number, 0x1163fa3);
+        assert_eq!(safe.unwrap().number, 0xe4e364);
     }
 }

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -279,50 +279,50 @@ mod tests {
                     r#"[
                       "0x1163fd1",
                       {
-                        "baseFeePerGas": "0xb7bd4ece6",
-                        "difficulty": "0x30f9a5c24b37e8",
-                        "extraData": "0x75732d77657374312d38",
-                        "gasLimit": "0x1ca35d2",
-                        "gasUsed": "0xc05fcf",
-                        "hash": "0x0950f85eb900296a98747b00ff2acfdeb1e5dba5060ee3fd25b83aaec6b24215",
-                        "logsBloom": "0x5d32840202020937554098c4b210833104680b9366c803640c74b0c80058114e0042c3cc11824470b40c50f0068f0783031a421a2b0fb9245250ac01302825889908960070244828a8c327aa8984602501472c8cc1630c988e435e218300601713a900d08e624e861f0408b901418fb02724001ced0886a954b5141dc07a0d891234490302225447108a030120840570352caa4131a6405a28e009505314c480af122327b3e0e91e06000b860e8a448040158e2923c3058a6162806454cae51c7120e683404b0c17450626c4085e330026f5bacd40082998ca000f8e18792010a038628a01100283270a0030396b59208870084534dc40e2004539a22b109e27",
-                        "miner": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
-                        "mixHash": "0x2795bc665f9ccdffd3d8ef28b29401cad05a5f4ffe88acf206c0f6d06880ebd2",
-                        "nonce": "0xedb67ceba7323a68",
-                        "number": "0xe4e364",
-                        "parentHash": "0x7436cc9a28f3ab1265a252ba36d5d7042641369043a140e99e43bff98d58f015",
-                        "receiptsRoot": "0x07c332da0afbe0a02195af3fe91445f785b7ec96e149e83eb959ab2127d8b396",
+                        "baseFeePerGas": "0x1418f329",
+                        "difficulty": "0x0",
+                        "extraData": "0x",
+                        "gasLimit": "0x1c9c380",
+                        "gasUsed": "0xb76d",
+                        "hash": "0xfc70e073ec6e1bb7f387698e4be418d7b1ff2216f625cdf41e1b80fb08029ef5",
+                        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                        "miner": "0x4200000000000000000000000000000000000011",
+                        "mixHash": "0x8bc8a48326d9309959f2452206c1c842be9fcc9840c789845caab9d290a9700c",
+                        "nonce": "0x0000000000000000",
+                        "number": "0x112",
+                        "parentHash": "0xcfbc479d5f63476538db9ff15295167a6e91ecc9d6cf54be471eded689c251c9",
+                        "receiptsRoot": "0x8c303881b3e408cc739f55ef3e5133075d552cbec9ee987aff6b71f58cf291ee",
                         "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-                        "size": "0xdf00",
-                        "stateRoot": "0xcdcfa6bb77e0364841d015b1e84fafcd0c3f8ed1db959f0bb2c38c287c6aea9a",
-                        "timestamp": "0x62b147f5",
-                        "totalDifficulty": "0xb0e7fa732d136d6e1f4",
+                        "size": "0x38a",
+                        "stateRoot": "0x86be45fb7a22b8c12cbce8d538372b800377cc589de590b6d88f5f65dde97df8",
+                        "timestamp": "0x65da607b",
+                        "totalDifficulty": "0x0",
                         "transactions": [
-                            {
-                                "blockHash": "0x0950f85eb900296a98747b00ff2acfdeb1e5dba5060ee3fd25b83aaec6b24215",
-                                "blockNumber": "0xe4e364",
-                                "from": "0x475ef7c1493bb29642529c30ad9bd4d1f27aed98",
-                                "gas": "0xc05a",
-                                "gasPrice": "0xba43b7400",
-                                "maxPriorityFeePerGas": "0x9502f900",
-                                "maxFeePerGas": "0xba43b7400",
-                                "hash": "0x20ea0eb2a3a3928ccfa86246fdf5f1f4ddd8c98a04f67ace5e149e22ecfe6b3a",
-                                "input": "0xa22cb4650000000000000000000000001e0049783f008a0085193e00003d00cd54003c710000000000000000000000000000000000000000000000000000000000000001",
-                                "nonce": "0x26a",
-                                "to": "0x2ee6af0dff3a1ce3f7e3414c52c48fd50d73691e",
-                                "transactionIndex": "0x87",
-                                "value": "0x0",
-                                "type": "0x2",
-                                "accessList": [],
-                                "chainId": "0x1",
-                                "v": "0x0",
-                                "r": "0x269746c7467dcb8d6535ff2ec3cc2257872bd9f55564b1b364e750263f831902",
-                                "s": "0x2c391ac90acdd9cf0f4e28f3647a9be74b05a7b261a83c0ae8199c733012a415",
-                                "yParity": "0x1"
-                              }
+                          {
+                            "blockHash": "0xfc70e073ec6e1bb7f387698e4be418d7b1ff2216f625cdf41e1b80fb08029ef5",
+                            "blockNumber": "0x112",
+                            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                            "gas": "0xf4240",
+                            "gasPrice": "0x0",
+                            "hash": "0x13a644af4f64ce801dcd57faa823e8952f2290b810fdd31995dda62977ed3df1",
+                            "input": "0x015d8eb90000000000000000000000000000000000000000000000000000000001267f330000000000000000000000000000000000000000000000000000000065da6073000000000000000000000000000000000000000000000000000000075d3f861097c24796a4f639846a6a3ea3a59c11de8d89e11f551bae8feca9271a78926d420000000000000000000000000000000000000000000000000000000000000004000000000000000000000000415c8893d514f9bc5211d36eeda4183226b84aa700000000000000000000000000000000000000000000000000000000000000bc00000000000000000000000000000000000000000000000000000000000a6fe0",
+                            "nonce": "0x111",
+                            "to": "0x4200000000000000000000000000000000000015",
+                            "transactionIndex": "0x0",
+                            "value": "0x0",
+                            "type": "0x7e",
+                            "v": "0x0",
+                            "r": "0x0",
+                            "s": "0x0",
+                            "sourceHash": "0x5a1b66228a26547e2ce6fe1aa734d2c34e062e42ccd5710463e6987890f1ad5d",
+                            "mint": "0x0",
+                            "depositReceiptVersion": "0x1"
+                          }
                         ],
-                        "transactionsRoot": "0xfe498a1338059330121151a24a01070321a63bbd2c82607ae747a26cd493e141",
-                        "uncles": []
+                        "transactionsRoot": "0xb01a2ad2c1ceb76f2edcdc02f2e0453c52e24c421fb04132cdfc0da5b70a593e",
+                        "uncles": [],
+                        "withdrawals": [],
+                        "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
                       },
                       [
                         {
@@ -358,6 +358,6 @@ mod tests {
             }
         );
         assert_eq!(latest, 0x1163fd1);
-        assert_eq!(safe.unwrap().number, 0xe4e364);
+        assert_eq!(safe.unwrap().number, 0x112);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -436,8 +436,9 @@ pub struct SignedEip2930Transaction {
     /// Chain ID that the transaction is valid on.
     pub chain_id: U256,
     /// Y parity of the signature.
-    #[serde(alias = "v")]
-    pub y_parity: YParity,
+    pub y_parity: Option<YParity>,
+    /// V
+    pub v: YParity,
     /// R
     pub r: U256,
     /// S
@@ -497,8 +498,9 @@ pub struct SignedEip1559Transaction {
     /// Chain ID that the transaction is valid on.
     pub chain_id: U256,
     /// Y parity of the signature.
-    #[serde(alias = "v")]
-    pub y_parity: YParity,
+    pub y_parity: Option<YParity>,
+    /// V
+    pub v: YParity,
     /// R
     pub r: U256,
     /// S
@@ -565,8 +567,9 @@ pub struct SignedEip4844Transaction {
     /// Chain ID that the transaction is valid on.
     pub chain_id: U256,
     /// Y parity of the signature.
-    #[serde(alias = "v")]
-    pub y_parity: YParity,
+    pub y_parity: Option<YParity>,
+    /// V
+    pub v: YParity,
     /// R
     pub r: U256,
     /// S

--- a/src/types.rs
+++ b/src/types.rs
@@ -643,6 +643,7 @@ pub struct Block {
     #[serde(with = "serialization::bytes")]
     pub extra_data: Vec<u8>,
     /// The mix hash.
+    #[serde(default)]
     pub mix_hash: Digest,
     /// The nonce.
     pub nonce: BlockNonce,

--- a/src/types.rs
+++ b/src/types.rs
@@ -646,7 +646,7 @@ pub struct Block {
     #[serde(default)]
     pub mix_hash: Digest,
     /// The nonce.
-    pub nonce: BlockNonce,
+    pub nonce: Option<BlockNonce>,
     /// The total difficulty.
     pub total_difficulty: U256,
     /// The base fee per gas.

--- a/src/types.rs
+++ b/src/types.rs
@@ -243,6 +243,9 @@ pub enum SignedTransaction {
     /// Signed EIP-4844 transaction.
     #[serde(rename = "0x3")]
     Eip4844(SignedEip4844Transaction),
+    /// Undocumented BLAST System Tx
+    #[serde(rename = "0x7e")]
+    BlastSystemTx(BlastSystemTransaction),
 }
 
 impl SignedTransaction {
@@ -252,6 +255,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.nonce,
             SignedTransaction::Eip1559(tx) => tx.nonce,
             SignedTransaction::Eip4844(tx) => tx.nonce,
+            Self::BlastSystemTx(tx) => tx.nonce,
         }
     }
 
@@ -261,6 +265,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.to,
             SignedTransaction::Eip1559(tx) => tx.to,
             SignedTransaction::Eip4844(tx) => tx.to,
+            Self::BlastSystemTx(tx) => tx.to,
         }
     }
 
@@ -270,6 +275,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.from,
             SignedTransaction::Eip1559(tx) => tx.from,
             SignedTransaction::Eip4844(tx) => tx.from,
+            Self::BlastSystemTx(tx) => tx.from,
         }
     }
 
@@ -279,6 +285,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.gas,
             SignedTransaction::Eip1559(tx) => tx.gas,
             SignedTransaction::Eip4844(tx) => tx.gas,
+            Self::BlastSystemTx(tx) => tx.gas,
         }
     }
 
@@ -288,6 +295,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.value,
             SignedTransaction::Eip1559(tx) => tx.value,
             SignedTransaction::Eip4844(tx) => tx.value,
+            Self::BlastSystemTx(tx) => tx.value,
         }
     }
 
@@ -297,6 +305,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.transaction_index,
             SignedTransaction::Eip1559(tx) => tx.transaction_index,
             SignedTransaction::Eip4844(tx) => tx.transaction_index,
+            Self::BlastSystemTx(tx) => tx.transaction_index,
         }
     }
 
@@ -306,6 +315,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.input.clone(),
             SignedTransaction::Eip1559(tx) => tx.input.clone(),
             SignedTransaction::Eip4844(tx) => tx.input.clone(),
+            Self::BlastSystemTx(tx) => tx.input.clone(),
         }
     }
 
@@ -315,6 +325,7 @@ impl SignedTransaction {
             SignedTransaction::Eip2930(tx) => tx.hash,
             SignedTransaction::Eip1559(tx) => tx.hash,
             SignedTransaction::Eip4844(tx) => tx.hash,
+            Self::BlastSystemTx(tx) => tx.hash,
         }
     }
 }
@@ -598,6 +609,42 @@ impl Debug for SignedEip4844Transaction {
             .field("s", &self.s)
             .finish()
     }
+}
+
+/// Signed EIP-4844 transaction.
+#[derive(Clone, Eq, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlastSystemTransaction {
+    /// The transaction nonce.
+    pub nonce: U256,
+    /// The transaction recipient.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<Address>,
+    /// The transaction sender.
+    pub from: Address,
+    /// The limit in gas units for the transaction.
+    pub gas: U256,
+    /// Gas price willing to be paid by the sender.
+    pub gas_price: U256,
+    /// The Ether value associated with the transaction.
+    pub value: U256,
+    /// The index of the transaction
+    pub transaction_index: U256,
+    /// The calldata associated with the transaction.
+    #[serde(with = "serialization::bytes")]
+    pub input: Vec<u8>,
+    /// Hash of the signed transaction.
+    pub hash: Digest,
+    /// V
+    pub v: YParity,
+    /// R
+    pub r: U256,
+    /// S
+    pub s: U256,
+    // Undocumented extra fields.
+    pub source_hash: Digest,
+    pub mint: U256,
+    pub deposit_receipt_version: U256,
 }
 
 /// A validator withdrawal.
@@ -1184,5 +1231,46 @@ impl Debug for TransactionReceipt {
             .field("logs_bloom", &self.logs_bloom)
             .field("status", &self.status)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_tx_serialization() {
+        let json_str = r#"{
+                        "blockHash": "0xfc70e073ec6e1bb7f387698e4be418d7b1ff2216f625cdf41e1b80fb08029ef5",
+                        "blockNumber": "0x112",
+                        "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                        "gas": "0xf4240",
+                        "gasPrice": "0x0",
+                        "hash": "0x13a644af4f64ce801dcd57faa823e8952f2290b810fdd31995dda62977ed3df1",
+                        "input": "0x015d8eb90000000000000000000000000000000000000000000000000000000001267f330000000000000000000000000000000000000000000000000000000065da6073000000000000000000000000000000000000000000000000000000075d3f861097c24796a4f639846a6a3ea3a59c11de8d89e11f551bae8feca9271a78926d420000000000000000000000000000000000000000000000000000000000000004000000000000000000000000415c8893d514f9bc5211d36eeda4183226b84aa700000000000000000000000000000000000000000000000000000000000000bc00000000000000000000000000000000000000000000000000000000000a6fe0",
+                        "nonce": "0x111",
+                        "to": "0x4200000000000000000000000000000000000015",
+                        "transactionIndex": "0x0",
+                        "value": "0x0",
+                        "type": "0x7e",
+                        "v": "0x0",
+                        "r": "0x0",
+                        "s": "0x0",
+                        "sourceHash": "0x5a1b66228a26547e2ce6fe1aa734d2c34e062e42ccd5710463e6987890f1ad5d",
+                        "mint": "0x0",
+                        "depositReceiptVersion": "0x1"
+                      }"#;
+        let result: Result<SignedTransaction, serde_json::Error> = serde_json::from_str(json_str);
+        println!("{:?}", result);
+        assert!(result.is_ok());
+
+        if let Ok(transaction) = result {
+            match transaction {
+                SignedTransaction::BlastSystemTx(_tx) => {
+                    // Could perform further checks on `tx` if needed
+                }
+                _ => panic!("Deserialized to the wrong variant of SignedTransaction"),
+            }
+        }
     }
 }


### PR DESCRIPTION
Some networks (e.g. Gnosis Chain) don't have mixHash along with a few other fields that were made optional.